### PR TITLE
Create twoFactorService.ts

### DIFF
--- a/src/services/twoFactorService.ts
+++ b/src/services/twoFactorService.ts
@@ -1,11 +1,15 @@
 import { authenticator } from 'otplib';
 import QRCode from 'qrcode';
 import { PrismaClient } from '@prisma/client';
+import validator from 'validator';
 
 const prisma = new PrismaClient();
 const SERVICE_NAME = 'XpertTradeBot'; // The name displayed in the auth app
 
 export const generateTwoFactorSecret = async (userId: string, email: string) => {
+  if (!validator.isEmail(email)) {
+    throw new Error('Invalid email address');
+  }
   const secret = authenticator.generateSecret();
   
   // generate the otpauth URL for the QR code

--- a/src/services/twoFactorService.ts
+++ b/src/services/twoFactorService.ts
@@ -1,0 +1,45 @@
+import { authenticator } from 'otplib';
+import QRCode from 'qrcode';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const SERVICE_NAME = 'XpertTradeBot'; // The name displayed in the auth app
+
+export const generateTwoFactorSecret = async (userId: string, email: string) => {
+  const secret = authenticator.generateSecret();
+  
+  // generate the otpauth URL for the QR code
+  const otpauth = authenticator.keyuri(email, SERVICE_NAME, secret);
+  
+  // Generate QR code data URL
+  const qrCodeUrl = await QRCode.toDataURL(otpauth);
+
+  // Save the secret to the user (but don't enable it yet!)
+  await prisma.user.update({
+    where: { id: userId },
+    data: { twoFactorSecret: secret },
+  });
+
+  return { secret, qrCodeUrl };
+};
+
+export const verifyTwoFactorToken = async (userId: string, token: string) => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+
+  if (!user || !user.twoFactorSecret) {
+    throw new Error('2FA setup not initiated');
+  }
+
+  // Verify the token against the secret
+  const isValid = authenticator.check(token, user.twoFactorSecret);
+
+  if (isValid) {
+    // If valid, officially enable 2FA for the user
+    await prisma.user.update({
+      where: { id: userId },
+      data: { isTwoFactorEnabled: true },
+    });
+  }
+
+  return isValid;
+};


### PR DESCRIPTION
This pull request introduces a new service for handling two-factor authentication (2FA) for users. The service allows users to generate a 2FA secret and QR code for setup, and verify tokens to enable 2FA on their account.

New two-factor authentication service:

* Added `generateTwoFactorSecret` function to create a 2FA secret, generate a QR code for authenticator apps, and store the secret in the user's record without enabling 2FA yet.
* Added `verifyTwoFactorToken` function to validate a user's 2FA token and enable 2FA if the token is correct.
* Integrated `otplib` for secret generation and verification, `qrcode` for QR code creation, and `PrismaClient` for database access.